### PR TITLE
Cleanup Dockerfiles

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,6 @@ services:
     php:
         image: ghcr.io/hermann8u/psr-portfolio/php:latest
         tmpfs:
-            - /var/psr-portfolio/var:mode=700,uid=82,gid=82
+            - /var/www/psr-portfolio/var:mode=700,uid=82,gid=82
         networks:
             - portfolio-internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ services:
             - "${PF_HTTP_PORT:-8080}:80"
         volumes:
             - ./docker/http/nginx.conf:/etc/nginx/conf.d/default.conf:ro
-            - ./public:/var/psr-portfolio/public:rw
+            - ./public:/var/www/psr-portfolio/public:rw
     php:
         build:
             target: dev
             dockerfile: ./docker/php/Dockerfile
             context: .
         volumes:
-            - ./:/var/psr-portfolio:rw
+            - ./:/var/www/psr-portfolio:rw
         tmpfs:
-            - /var/psr-portfolio/var:mode=700,uid=82,gid=82
+            - /var/www/psr-portfolio/var:mode=700,uid=82,gid=82

--- a/docker/http/Dockerfile
+++ b/docker/http/Dockerfile
@@ -1,23 +1,29 @@
 FROM registry.hub.docker.com/library/node:14.16-alpine AS node
 
 WORKDIR /node
-COPY package.json .
-COPY package-lock.json .
+
+COPY ./package.json ./
+COPY ./package-lock.json ./
+
 RUN npm ci
 
-COPY assets /node/assets
-COPY postcss.config.js /node/postcss.config.js
-COPY tailwind.config.js /node/tailwind.config.js
-COPY webpack.config.js /node/webpack.config.js
-COPY src /node/src
-COPY templates /node/templates
+COPY ./assets ./
+COPY ./postcss.config.js ./
+COPY ./tailwind.config.js ./
+COPY ./webpack.config.js ./
+COPY ./src ./
+COPY ./templates ./
+
 RUN npm run build
 
 FROM registry.hub.docker.com/library/nginx:1.19-alpine
 
 COPY ./docker/http/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=node /node/public /var/psr-portfolio/public
-COPY ./public/img /var/psr-portfolio/public/img
-COPY ./public/favicon.ico /var/psr-portfolio/public/favicon.ico
-COPY ./public/robots.txt /var/psr-portfolio/public/robots.txt
-COPY ./public/sitemap.xml /var/psr-portfolio/public/sitemap.xml
+
+WORKDIR /var/www/psr-portfolio/public
+
+COPY --from=node /node/public ./
+COPY ./public/img ./
+COPY ./public/favicon.ico ./
+COPY ./public/robots.txt ./
+COPY ./public/sitemap.xml ./

--- a/docker/http/nginx.conf
+++ b/docker/http/nginx.conf
@@ -7,7 +7,7 @@ server {
     #access_log  /var/log/nginx/host.access.log  main;
 
     location / {
-        root   /var/psr-portfolio/public;
+        root   /var/www/psr-portfolio/public;
         index  index.php;
         try_files $uri /index.php$is_args$args;
     }
@@ -35,7 +35,7 @@ server {
         root           html;
         fastcgi_pass   $upstream;
         fastcgi_index  index.php;
-        fastcgi_param  SCRIPT_FILENAME  /var/psr-portfolio/public$fastcgi_script_name;
+        fastcgi_param  SCRIPT_FILENAME  /var/www/psr-portfolio/public$fastcgi_script_name;
         include        fastcgi_params;
     }
 

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -8,13 +8,15 @@ RUN apk --no-cache update && \
     apk add git unzip libzip-dev && \
     docker-php-ext-install zip
 
-COPY ./composer.json /composer/composer.json
-COPY ./composer.lock /composer/composer.lock
-
 WORKDIR /composer
 
+COPY ./composer.json ./
+COPY ./composer.lock ./
+COPY ./src ./
+
 RUN curl --silent --show-error https://getcomposer.org/installer | php
-RUN php composer.phar install \
+RUN mv /composer/composer.phar /usr/local/bin/composer
+RUN composer install \
     --no-interaction \
     --no-dev \
     --optimize-autoloader \
@@ -25,32 +27,37 @@ RUN php composer.phar install \
     --no-progress \
     --quiet
 
-COPY ./src /composer/src
-RUN php composer.phar dump-autoload  \
-    --no-interaction \
-    --no-dev \
-    --optimize \
-    --classmap-authoritative \
-    --no-scripts \
-    --quiet
-
 FROM composer AS dev
 
 ENV APP_ENV dev
 ENV APP_DEBUG 1
 
-# install xdebug
+WORKDIR /var/www/psr-portfolio
+
+COPY ./composer.json ./
+COPY ./composer.lock ./
+
+RUN composer install \
+    --no-interaction \
+    --no-scripts \
+    --no-suggest \
+    --no-progress \
+    --quiet
+
+# TODO: Install xdebug
 
 FROM base AS prod
 
 ENV APP_ENV prod
 ENV APP_DEBUG 0
 
-COPY ./config /var/psr-portfolio/config
-COPY ./src /var/psr-portfolio/src
-COPY ./public/index.php /var/psr-portfolio/public/index.php
-COPY ./templates /var/psr-portfolio/templates
-COPY ./data /var/psr-portfolio/data
-COPY --from=composer /composer/vendor /var/psr-portfolio/vendor
+WORKDIR /var/www/psr-portfolio
+
+COPY ./config ./
+COPY ./src ./
+COPY ./public/index.php ./public/
+COPY ./templates ./
+COPY ./data ./
+COPY --from=composer /composer/vendor ./
 
 RUN mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini


### PR DESCRIPTION
This PR aims to cleanup some code related to the docker integration. Moreover, the project path on the container has been changed from `/var/psr-portfolio/` to `/var/www/psr-portfolio/` which correspond to the default nginx folder to store projects.

The only thing I'm not sure about is the second composer install in `docker/php/Dockerfile`. It is needed to have the dev dependencies installed in the local dev environment. The problem is that we can't skip this stage during the image creation for production.